### PR TITLE
记录打包过的文件

### DIFF
--- a/libs/image.js
+++ b/libs/image.js
@@ -121,7 +121,9 @@ Generator.prototype = {
         }
         return false;
     },
-    after: function (group, image, arr_selector, direct, scale) {
+    after: function (group, image, arr_selector, direct, scale, list) {
+        var that = this;
+
         var ext = '_' + direct + '.png';
         var size = image.size();
         if (this.index) {
@@ -142,6 +144,15 @@ Generator.prototype = {
         image_file.setContent(image.encode('png'));
         fis.compile(image_file);
         this.ret.pkg[pkg_path] = image_file;
+
+        // 记录这些图片已经被打包到其他文件上了。
+        list.forEach(function(image) {
+            var srcImage = that.images[image.image];
+
+            console.log(srcImage.fullname);
+            var map = srcImage.map = srcImage.map || {};
+            map.cssspritePkg = image_file.getId();
+        });
 
         function unique(arr) {
             var map = {};
@@ -259,7 +270,7 @@ Generator.prototype = {
             }
         }
 
-        this.after(group, image, cls, direct);
+        this.after(group, image, cls, direct, null, list);
     },
     zFill: function(group, list, scale) {
         if (!list || list.length == 0) {
@@ -401,6 +412,6 @@ Generator.prototype = {
                 y += current.h;
             }
         }
-        this.after(group, image, cls, 'z', scale);
+        this.after(group, image, cls, 'z', scale, list);
     }
 };

--- a/libs/image.js
+++ b/libs/image.js
@@ -148,8 +148,6 @@ Generator.prototype = {
         // 记录这些图片已经被打包到其他文件上了。
         list.forEach(function(image) {
             var srcImage = that.images[image.image];
-
-            console.log(srcImage.fullname);
             var map = srcImage.map = srcImage.map || {};
             map.cssspritePkg = image_file.getId();
         });


### PR DESCRIPTION
您好！最近在使用官方提供的[fis3-deploy-skip-packed](https://github.com/fex-team/fis3-deploy-skip-packed)插件时，发现被合成雪碧图的图片无法被过滤，发现是文件的map对象属性缺少cssspritePkg属性导致，所以参考官方的[fis-spriter-csssprites](https://github.com/fex-team/fis-spriter-csssprites)插件，添加了记录打包过文件的代码。
由于最近团队在考虑使用fis3工具进行开发调试，使用了您的插件，还望采纳或者添加类似的功能，多谢！
